### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Built in Swift 1.2 for iOS 8.0+. All devices supported. can be used in both Swif
 
 ## Adding BMPickerModal To Your Project
 
-### Cocoapods
+### CocoaPods
 
 CocoaPods is the recommended way to add BMPickerModal to your project. As BMPickerModal is written in Swift, you need to add the `use_frameworks!` option to your podfile.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
